### PR TITLE
PAPP-36662: use configured API key in urlscan action request headers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,7 +27,7 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.12.9
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
@@ -55,7 +55,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.5
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # urlscan.io
 
-Publisher: Splunk \
-Connector Version: 2.6.2 \
-Product Vendor: urlscan.io \
-Product Name: urlscan.io \
+Publisher: Splunk <br>
+Connector Version: 2.6.2 <br>
+Product Vendor: urlscan.io <br>
+Product Name: urlscan.io <br>
 Minimum Product Version: 6.2.1
 
 This app supports investigative actions on urlscan.io
@@ -33,18 +33,18 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[get report](#action-get-report) - Query for results of an already completed detonation \
-[lookup domain](#action-lookup-domain) - Find information about a domain at urlscan.io \
-[lookup ip](#action-lookup-ip) - Find information about an IP address at urlscan.io \
-[detonate url](#action-detonate-url) - Detonate a URL at urlscan.io \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[get report](#action-get-report) - Query for results of an already completed detonation <br>
+[lookup domain](#action-lookup-domain) - Find information about a domain at urlscan.io <br>
+[lookup ip](#action-lookup-ip) - Find information about an IP address at urlscan.io <br>
+[detonate url](#action-detonate-url) - Detonate a URL at urlscan.io <br>
 [get screenshot](#action-get-screenshot) - Retrieve copy of screenshot file
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 This will attempt to connect by running an action which would require usage of the API key. If there is no API key set, it will still run a query to make sure the <b>urlscan.io</b> API can be queried.
@@ -61,7 +61,7 @@ No Output
 
 Query for results of an already completed detonation
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -700,7 +700,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Find information about a domain at urlscan.io
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -756,7 +756,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Find information about an IP address at urlscan.io
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -812,7 +812,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Detonate a URL at urlscan.io
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **False**
 
 If the get_result parameter is set to true, then the action may take up to 2-3 minutes to execute because the action will poll for the results in the same call.
@@ -1709,7 +1709,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Retrieve copy of screenshot file
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **True**
 
 #### Action Parameters

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fixed hunt domain and hunt IP actions to use configured API key

--- a/urlscan_connector.py
+++ b/urlscan_connector.py
@@ -529,9 +529,13 @@ class UrlscanConnector(BaseConnector):
             self._state = {"app_version": self.get_app_json().get("app_version")}
 
         config = self.get_config()
-        self._api_key = config.get("api_key")
+        self._api_key = config.get("api_key", "")
         self.timeout = config.get("timeout", 120)
         self.set_validator("ipv6", self._is_ip)
+
+        if self._api_key is None:
+            self.debug_print("No API key found, setting to empty string")
+            self._api_key = ""
 
         return phantom.APP_SUCCESS
 

--- a/urlscan_connector.py
+++ b/urlscan_connector.py
@@ -223,10 +223,10 @@ class UrlscanConnector(BaseConnector):
         self.debug_print(f"In action handler for {self.get_action_identifier()}")
 
         action_result = self.add_action_result(ActionResult(dict(param)))
-
+        headers = {"API-Key": self._api_key}
         domain = param["domain"]
 
-        ret_val, response = self._make_rest_call(URLSCAN_HUNT_DOMAIN_ENDPOINT.format(domain), action_result, params=None, headers=None)
+        ret_val, response = self._make_rest_call(URLSCAN_HUNT_DOMAIN_ENDPOINT.format(domain), action_result, params=None, headers=headers)
 
         if phantom.is_fail(ret_val):
             if not action_result.get_message():
@@ -248,8 +248,8 @@ class UrlscanConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         ip = param["ip"]
-
-        ret_val, response = self._make_rest_call(URLSCAN_HUNT_IP_ENDPOINT.format(ip), action_result, params=None, headers=None)
+        headers = {"API-Key": self._api_key}
+        ret_val, response = self._make_rest_call(URLSCAN_HUNT_IP_ENDPOINT.format(ip), action_result, params=None, headers=headers)
 
         if phantom.is_fail(ret_val):
             if not action_result.get_message():


### PR DESCRIPTION

### Bug Fixes

Use configured api-keys while running actions. 
https://splunk.atlassian.net/browse/PAPP-36662