### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # urlscan.io
 
-Publisher: Splunk \
-Connector Version: 2.6.2 \
-Product Vendor: urlscan.io \
-Product Name: urlscan.io \
+Publisher: Splunk <br>
+Connector Version: 2.6.2 <br>
+Product Vendor: urlscan.io <br>
+Product Name: urlscan.io <br>
 Minimum Product Version: 6.2.1
 
 This app supports investigative actions on urlscan.io
@@ -33,18 +33,18 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[get report](#action-get-report) - Query for results of an already completed detonation \
-[lookup domain](#action-lookup-domain) - Find information about a domain at urlscan.io \
-[lookup ip](#action-lookup-ip) - Find information about an IP address at urlscan.io \
-[detonate url](#action-detonate-url) - Detonate a URL at urlscan.io \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[get report](#action-get-report) - Query for results of an already completed detonation <br>
+[lookup domain](#action-lookup-domain) - Find information about a domain at urlscan.io <br>
+[lookup ip](#action-lookup-ip) - Find information about an IP address at urlscan.io <br>
+[detonate url](#action-detonate-url) - Detonate a URL at urlscan.io <br>
 [get screenshot](#action-get-screenshot) - Retrieve copy of screenshot file
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 This will attempt to connect by running an action which would require usage of the API key. If there is no API key set, it will still run a query to make sure the <b>urlscan.io</b> API can be queried.
@@ -61,7 +61,7 @@ No Output
 
 Query for results of an already completed detonation
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -700,7 +700,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Find information about a domain at urlscan.io
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -756,7 +756,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Find information about an IP address at urlscan.io
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -812,7 +812,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Detonate a URL at urlscan.io
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **False**
 
 If the get_result parameter is set to true, then the action may take up to 2-3 minutes to execute because the action will poll for the results in the same call.
@@ -1709,7 +1709,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Retrieve copy of screenshot file
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **True**
 
 #### Action Parameters

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13

--- a/urlscan.json
+++ b/urlscan.json
@@ -12,7 +12,7 @@
     "license": "Copyright (c) 2017-2025 Splunk Inc.",
     "app_version": "2.6.2",
     "utctime_updated": "2025-08-20T22:30:52.806256Z",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "package_name": "phantom_urlscan",
     "main_module": "urlscan_connector.py",

--- a/urlscan.json
+++ b/urlscan.json
@@ -11625,5 +11625,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)