### PR TITLE
fix: harden URLScan screenshot downloads and TLS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.40.7
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.0
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **api_key** | optional | password | API key for urlscan.io |
 **timeout** | optional | numeric | Timeout period for action (seconds) |
 **verify_server_cert** | optional | boolean | Verify server certificate |
+**max_screenshot_size_mb** | optional | numeric | Maximum screenshot download size in MiB |
 
 ### Supported Actions
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Verify urlscan.io TLS certificates by default while retaining an explicit opt-out. (PSAAS-32252)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Verify urlscan.io TLS certificates by default while retaining an explicit opt-out. (PSAAS-32252)
+* Stream screenshots through a bounded vault temporary file. (PSAAS-33424)

--- a/src/actions/screenshot.py
+++ b/src/actions/screenshot.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import tempfile
+from pathlib import Path
 from typing import Any
 
 from soar_sdk.abstract import SOARClient
@@ -22,7 +24,8 @@ from ..constants import (
     ERROR_INVALID_INT_PARAM,
     ERROR_NEG_INT_PARAM,
     ERROR_ZERO_INT_PARAM,
-    URLSCAN_NO_DATA_ERROR,
+    URLSCAN_DEFAULT_MAX_SCREENSHOT_SIZE_MB,
+    URLSCAN_INVALID_SCREENSHOT_SIZE_ERROR,
     URLSCAN_SCREENSHOT_ENDPOINT,
     URLSCAN_SCREENSHOT_SUCCESS_MESSAGE,
 )
@@ -42,12 +45,6 @@ def run_get_screenshot(
     if container_id is None:
         container_id = getattr(params, "container_id", None)
 
-    client = UrlscanClient.from_asset(asset)
-    response = client.request(URLSCAN_SCREENSHOT_ENDPOINT.format(report_id))
-
-    if not response.ok or response.response is None:
-        raise ActionFailure(response.message or URLSCAN_NO_DATA_ERROR)
-
     if container_id is None:
         container_id = soar.get_executing_container_id()
 
@@ -63,16 +60,35 @@ def run_get_screenshot(
     if container_id < 0:
         raise ActionFailure(ERROR_NEG_INT_PARAM.format(key="container_id"))
 
-    file_type = response.response.headers.get(
-        "Content-Type", "application/octet-stream"
+    max_size_mb = getattr(
+        asset, "max_screenshot_size_mb", URLSCAN_DEFAULT_MAX_SCREENSHOT_SIZE_MB
     )
-    extension = response.response.url.path.rsplit(".", 1)[-1]
-    file_name = f"{report_id}.{extension}" if extension else report_id
+    if (
+        not isinstance(max_size_mb, int)
+        or isinstance(max_size_mb, bool)
+        or max_size_mb <= 0
+    ):
+        raise ActionFailure(URLSCAN_INVALID_SCREENSHOT_SIZE_ERROR)
+    max_size_bytes = max_size_mb * 1024 * 1024
 
+    temporary_file: Path | None = None
     try:
-        vault_id = soar.vault.create_attachment(
+        with tempfile.NamedTemporaryFile(
+            mode="wb", dir=soar.vault.get_vault_tmp_dir(), delete=False
+        ) as destination:
+            temporary_file = Path(destination.name)
+            client = UrlscanClient.from_asset(asset)
+            file_type, response_path = client.download_screenshot(
+                URLSCAN_SCREENSHOT_ENDPOINT.format(report_id),
+                destination,
+                max_size_bytes,
+            )
+
+        extension = response_path.rsplit(".", 1)[-1]
+        file_name = f"{report_id}.{extension}" if extension else report_id
+        vault_id = soar.vault.add_attachment(
             container_id=container_id,
-            file_content=response.response.content,
+            file_location=str(temporary_file),
             file_name=file_name,
         )
         attachments = soar.vault.get_attachment(
@@ -82,10 +98,13 @@ def run_get_screenshot(
             raise SoarAPIError(
                 "Could not find meta information of the downloaded screenshot's Vault"
             )
-    except SoarAPIError as exc:
+    except (OSError, SoarAPIError) as exc:
         raise ActionFailure(
             f"Failed to download screenshot in Vault. Error : {exc}"
         ) from exc
+    finally:
+        if temporary_file is not None:
+            temporary_file.unlink(missing_ok=True)
 
     attachment = attachments[0]
     screenshot_data = {

--- a/src/app.py
+++ b/src/app.py
@@ -52,7 +52,7 @@ class Asset(BaseAsset):
         description="Timeout period for action (seconds)", default=120.0
     )
     verify_server_cert: bool | None = AssetField(
-        description="Verify server certificate", default=False
+        description="Verify server certificate", default=True
     )
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -54,6 +54,9 @@ class Asset(BaseAsset):
     verify_server_cert: bool | None = AssetField(
         description="Verify server certificate", default=True
     )
+    max_screenshot_size_mb: int | None = AssetField(
+        description="Maximum screenshot download size in MiB", default=25
+    )
 
 
 app = App(

--- a/src/client.py
+++ b/src/client.py
@@ -64,7 +64,7 @@ class UrlscanClient:
         return cls(
             api_key=getattr(asset, "api_key", None),
             timeout=getattr(asset, "timeout", None),
-            verify_server_cert=getattr(asset, "verify_server_cert", False),
+            verify_server_cert=getattr(asset, "verify_server_cert", True),
         )
 
     def _get_error_message_from_exception(self, exc: Exception) -> str:

--- a/src/client.py
+++ b/src/client.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 import json
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, BinaryIO
 
 import httpx
 from bs4 import BeautifulSoup
 from soar_sdk.asset import BaseAsset
+from soar_sdk.exceptions import ActionFailure
 from soar_sdk.logging import getLogger
 
 from .constants import (
@@ -32,6 +33,8 @@ from .constants import (
     URLSCAN_NOT_FOUND_CODE,
     URLSCAN_PROCESS_RESPONSE_ERROR,
     URLSCAN_RATE_LIMIT_ERROR,
+    URLSCAN_SCREENSHOT_CHUNK_SIZE,
+    URLSCAN_SCREENSHOT_TOO_LARGE_ERROR,
     URLSCAN_SERVER_CONNECTIVITY_ERROR,
 )
 
@@ -204,3 +207,62 @@ class UrlscanClient:
             )
 
         return self._process_response(response)
+
+    def download_screenshot(
+        self, endpoint: str, destination: BinaryIO, max_size_bytes: int
+    ) -> tuple[str, str]:
+        max_size_mb = max_size_bytes // (1024 * 1024)
+        try:
+            with (
+                httpx.Client(
+                    base_url=URLSCAN_BASE_URL,
+                    timeout=self.timeout,
+                    follow_redirects=True,
+                    verify=self.verify_server_cert,
+                ) as client,
+                client.stream("GET", endpoint) as response,
+            ):
+                if response.status_code != 200:
+                    raise ActionFailure(
+                        URLSCAN_FILE_RESPONSE_ERROR.format(response.status_code)
+                    )
+
+                content_type = response.headers.get("Content-Type", "")
+                if "image" not in content_type and "octet-stream" not in content_type:
+                    raise ActionFailure(
+                        URLSCAN_FILE_RESPONSE_ERROR.format(response.status_code)
+                    )
+
+                content_length = response.headers.get("Content-Length")
+                if content_length:
+                    try:
+                        declared_size = int(content_length)
+                    except ValueError:
+                        declared_size = None
+                    if declared_size is not None and declared_size > max_size_bytes:
+                        raise ActionFailure(
+                            URLSCAN_SCREENSHOT_TOO_LARGE_ERROR.format(
+                                max_size_mb=max_size_mb
+                            )
+                        )
+
+                downloaded_size = 0
+                for chunk in response.iter_bytes(URLSCAN_SCREENSHOT_CHUNK_SIZE):
+                    downloaded_size += len(chunk)
+                    if downloaded_size > max_size_bytes:
+                        raise ActionFailure(
+                            URLSCAN_SCREENSHOT_TOO_LARGE_ERROR.format(
+                                max_size_mb=max_size_mb
+                            )
+                        )
+                    destination.write(chunk)
+
+                return (
+                    content_type or "application/octet-stream",
+                    response.url.path,
+                )
+        except httpx.HTTPError as exc:
+            error_message = self._get_error_message_from_exception(exc)
+            raise ActionFailure(
+                URLSCAN_SERVER_CONNECTIVITY_ERROR.format(error_message)
+            ) from exc

--- a/src/constants.py
+++ b/src/constants.py
@@ -16,6 +16,8 @@ URLSCAN_MAX_POLLING_ATTEMPTS = 10
 URLSCAN_POLLING_INTERVAL = 15
 URLSCAN_MAX_TAGS_NUM = 10
 URLSCAN_MAX_TAG_LENGTH = 29
+URLSCAN_DEFAULT_MAX_SCREENSHOT_SIZE_MB = 25
+URLSCAN_SCREENSHOT_CHUNK_SIZE = 64 * 1024
 URLSCAN_BAD_REQUEST_CODE = 400
 URLSCAN_NOT_FOUND_CODE = 404
 
@@ -61,6 +63,12 @@ URLSCAN_TAGS_OMITTED_NOTICE = "Omitted {0} tag(s) longer than {1} characters"
 URLSCAN_ACTION_SUCCESS = "Successfully retrieved information"
 URLSCAN_SCREENSHOT_SUCCESS_MESSAGE = (
     "Screenshot downloaded successfully in container : {container_id}"
+)
+URLSCAN_SCREENSHOT_TOO_LARGE_ERROR = (
+    "Screenshot exceeds the configured maximum download size of {max_size_mb} MiB"
+)
+URLSCAN_INVALID_SCREENSHOT_SIZE_ERROR = (
+    "Asset configuration max_screenshot_size_mb must be a positive integer"
 )
 ERROR_INVALID_INT_PARAM = (
     "Please provide a valid integer value in the '{key}' parameter"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,13 @@
+from types import SimpleNamespace
+
+from src.client import UrlscanClient
+
+
+def test_client_defaults_to_tls_verification_for_assets_without_the_field():
+    client = UrlscanClient.from_asset(SimpleNamespace(api_key=None, timeout=None))
+    assert client.verify_server_cert is True
+
+    opt_out = UrlscanClient.from_asset(
+        SimpleNamespace(api_key=None, timeout=None, verify_server_cert=False)
+    )
+    assert opt_out.verify_server_cert is False

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from types import SimpleNamespace
 
 from src.client import UrlscanClient

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import io
 from pathlib import Path
 from types import SimpleNamespace

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,0 +1,153 @@
+import io
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from soar_sdk.exceptions import ActionFailure, SoarAPIError
+
+from src.actions.screenshot import run_get_screenshot
+from src.client import UrlscanClient
+from src.constants import URLSCAN_DEFAULT_MAX_SCREENSHOT_SIZE_MB
+
+
+class StreamResponse:
+    def __init__(self, chunks: list[bytes], headers: dict[str, str] | None = None):
+        self.status_code = 200
+        self.headers = headers or {"Content-Type": "image/png"}
+        self.url = httpx.URL("https://urlscan.io/screenshots/example.png")
+        self._chunks = chunks
+        self.iterated = False
+
+    def iter_bytes(self, _chunk_size: int):
+        self.iterated = True
+        yield from self._chunks
+
+
+class StreamContext:
+    def __init__(self, response: StreamResponse):
+        self.response = response
+
+    def __enter__(self):
+        return self.response
+
+    def __exit__(self, *_args):
+        return False
+
+
+class HttpClient:
+    def __init__(self, response: StreamResponse, **_kwargs):
+        self.response = response
+        self.stream_calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def stream(self, *_args, **_kwargs):
+        self.stream_calls += 1
+        return StreamContext(self.response)
+
+
+def test_download_screenshot_rejects_declared_oversize_without_reading_body(mocker):
+    response = StreamResponse(
+        [b"body-must-not-be-read"],
+        {"Content-Type": "image/png", "Content-Length": "6"},
+    )
+    client = HttpClient(response)
+    mocker.patch("src.client.httpx.Client", return_value=client)
+
+    with pytest.raises(ActionFailure, match="maximum download size"):
+        UrlscanClient("", 30, True).download_screenshot("/screenshot", io.BytesIO(), 5)
+
+    assert client.stream_calls == 1
+    assert response.iterated is False
+
+
+def test_download_screenshot_stops_at_cumulative_limit(mocker):
+    response = StreamResponse([b"abc", b"def"])
+    mocker.patch("src.client.httpx.Client", return_value=HttpClient(response))
+    destination = io.BytesIO()
+
+    with pytest.raises(ActionFailure, match="maximum download size"):
+        UrlscanClient("", 30, True).download_screenshot("/screenshot", destination, 5)
+
+    assert destination.getvalue() == b"abc"
+
+
+class Vault:
+    def __init__(self, temporary_directory: Path, *, fail_add: bool = False):
+        self.temporary_directory = temporary_directory
+        self.fail_add = fail_add
+        self.added_file: Path | None = None
+
+    def get_vault_tmp_dir(self):
+        return str(self.temporary_directory)
+
+    def add_attachment(self, *, file_location, **_kwargs):
+        self.added_file = Path(file_location)
+        assert self.added_file.read_bytes() == b"screenshot"
+        if self.fail_add:
+            raise SoarAPIError("vault unavailable")
+        return "vault-id"
+
+    def get_attachment(self, **_kwargs):
+        return [
+            SimpleNamespace(
+                vault_id="vault-id",
+                name="screenshot.png",
+                id=7,
+                container_id=42,
+                size=10,
+            )
+        ]
+
+
+def write_screenshot(_endpoint, destination, _max_size):
+    destination.write(b"screenshot")
+    return "image/png", "/screenshots/example.png"
+
+
+def test_screenshot_vaults_streamed_file_and_removes_temporary_file(tmp_path, mocker):
+    vault = Vault(tmp_path)
+    soar = SimpleNamespace(
+        vault=vault,
+        get_executing_container_id=lambda: 42,
+        set_message=lambda _message: None,
+        set_summary=lambda _summary: None,
+    )
+    client = mocker.Mock()
+    client.download_screenshot.side_effect = write_screenshot
+    mocker.patch("src.actions.screenshot.UrlscanClient.from_asset", return_value=client)
+
+    result = run_get_screenshot(
+        SimpleNamespace(report_id="example", container_id=42),
+        soar,
+        SimpleNamespace(max_screenshot_size_mb=URLSCAN_DEFAULT_MAX_SCREENSHOT_SIZE_MB),
+    )
+
+    assert result.vault_id == "vault-id"
+    assert vault.added_file is not None
+    assert not vault.added_file.exists()
+
+
+def test_screenshot_removes_temporary_file_when_vaulting_fails(tmp_path, mocker):
+    vault = Vault(tmp_path, fail_add=True)
+    soar = SimpleNamespace(vault=vault, get_executing_container_id=lambda: 42)
+    client = mocker.Mock()
+    client.download_screenshot.side_effect = write_screenshot
+    mocker.patch("src.actions.screenshot.UrlscanClient.from_asset", return_value=client)
+
+    with pytest.raises(ActionFailure, match="vault unavailable"):
+        run_get_screenshot(
+            SimpleNamespace(report_id="example", container_id=42),
+            soar,
+            SimpleNamespace(
+                max_screenshot_size_mb=URLSCAN_DEFAULT_MAX_SCREENSHOT_SIZE_MB
+            ),
+        )
+
+    assert vault.added_file is not None
+    assert not vault.added_file.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -982,7 +982,7 @@ wheels = [
 
 [[package]]
 name = "urlscan"
-version = "3.0.0"
+version = "3.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },


### PR DESCRIPTION
## Summary

- verify URLScan TLS certificates by default for new and legacy assets; explicit `verify_server_cert: false` remains available
- add optional `max_screenshot_size_mb` with a 25 MiB default; screenshots are streamed to a vault temporary file, checked against both Content-Length and cumulative bytes, and removed on all exit paths
- avoid response-body logging on the screenshot download path

## Tracking

- PAPP-38305
- PSAAS-32252
- PSAAS-33424
- PSAAS-33208 is not included: URLScan's SDK migration already removed the affected legacy NUL sanitizer

## Compatibility

`verify_server_cert` now defaults to `true` when omitted. Set it explicitly to `false` only for an environment that requires the legacy behavior.

## Validation

- `uv run pytest -q` (5 passed)
- `pre-commit run --all-files` (all applicable hooks passed, including SOAR App Linter, Semgrep, generated docs, and static tests)

Written by Codex.